### PR TITLE
Add 'Mode Bac' checkbox with path validation and event logging

### DIFF
--- a/src/thonnycontrib/thonny-autosave/__init__.py
+++ b/src/thonnycontrib/thonny-autosave/__init__.py
@@ -41,6 +41,11 @@ def toggle_autosave():
     get_workbench().set_option("general.autosave", not get_workbench().get_option("general.autosave"))
 
 
+
+
+def _can_toggle_bac_mode() -> bool:
+    return not _is_bac_lock_period()
+
 def toggle_bac_mode():
     if _is_bac_lock_period():
         get_workbench().set_option("general.bac_mode", True)
@@ -162,9 +167,9 @@ def _blink_unsaved_untitled():
         return
 
     if _should_show_untitled_title:
-        editor_notebook.update_editor_title(editor, tr("<untitled>"))
+        editor_notebook.update_editor_title(editor, tr("<untitled>") + "*")
     else:
-        editor_notebook.update_editor_title(editor, " " * len(tr("<untitled>")))
+        editor_notebook.update_editor_title(editor, "<Enregistrez votre travail>")
 
     _should_show_untitled_title = not _should_show_untitled_title
 
@@ -209,6 +214,7 @@ def load_plugin():
         tr("Mode Bac"),
         flag_name="general.bac_mode",
         handler=toggle_bac_mode,
+        tester=_can_toggle_bac_mode,
     )
 
     get_workbench().bind("Save", _on_file_event, True)

--- a/src/thonnycontrib/thonny-autosave/__init__.py
+++ b/src/thonnycontrib/thonny-autosave/__init__.py
@@ -1,5 +1,5 @@
 import re
-from datetime import datetime
+from datetime import date, datetime
 from logging import getLogger
 from tkinter import messagebox
 
@@ -21,12 +21,33 @@ _UI_EXTENSION_WARNING = "En mode Bac, l'enregistrement des fichiers .ui est inte
 _original_save_file = None
 _original_ask_new_path = None
 
+_BAC_LOCK_START = date(2026, 5, 19)
+_BAC_LOCK_END = date(2026, 5, 23)
+
+
+
+
+def _is_bac_lock_period() -> bool:
+    today = datetime.now().date()
+    return _BAC_LOCK_START <= today <= _BAC_LOCK_END
+
+
+def _enforce_bac_mode_and_logging_if_required():
+    if _is_bac_lock_period():
+        get_workbench().set_option("general.bac_mode", True)
+        get_workbench().set_option("general.event_logging", True)
 
 def toggle_autosave():
     get_workbench().set_option("general.autosave", not get_workbench().get_option("general.autosave"))
 
 
 def toggle_bac_mode():
+    if _is_bac_lock_period():
+        get_workbench().set_option("general.bac_mode", True)
+        get_workbench().set_option("general.event_logging", True)
+        messagebox.showwarning("Mode Bac", "Du 19 mai 2026 au 23 mai 2026, le Mode Bac ne peut pas être désactivé.", master=get_workbench())
+        return
+
     enabled = not get_workbench().get_option("general.bac_mode")
     get_workbench().set_option("general.bac_mode", enabled)
     get_workbench().set_option("general.event_logging", enabled)
@@ -165,12 +186,15 @@ def save_current():
 
 
 def _on_workbench_ready(event):
+    _enforce_bac_mode_and_logging_if_required()
     _patch_editor_save_file()
     save_current()
     _blink_unsaved_untitled()
 
 
 def load_plugin():
+    _enforce_bac_mode_and_logging_if_required()
+
     get_workbench().add_command(
         "toggle_autosave",
         "file",

--- a/src/thonnycontrib/thonny-autosave/__init__.py
+++ b/src/thonnycontrib/thonny-autosave/__init__.py
@@ -67,7 +67,12 @@ def save_current():
     logger.info("entering save_current")
     get_workbench().after(10000, save_current)
 
-    editor = get_workbench().get_editor_notebook().get_current_editor()
+    try:
+        editor_notebook = get_workbench().get_editor_notebook()
+    except (AssertionError, AttributeError):
+        return
+
+    editor = editor_notebook.get_current_editor()
     if editor is None:
         return
 
@@ -100,5 +105,4 @@ def load_plugin():
     get_workbench().bind("Save", _on_file_event, True)
     get_workbench().bind("SaveAs", _on_file_event, True)
     get_workbench().bind("Open", _on_file_event, True)
-    logger.info("running save_current")
-    save_current()
+    get_workbench().bind("WorkbenchReady", lambda event: save_current(), True)

--- a/src/thonnycontrib/thonny-autosave/__init__.py
+++ b/src/thonnycontrib/thonny-autosave/__init__.py
@@ -19,6 +19,7 @@ _should_show_untitled_title = True
 
 _UI_EXTENSION_WARNING = "En mode Bac, l'enregistrement des fichiers .ui est interdit."
 _original_save_file = None
+_original_ask_new_path = None
 
 
 def toggle_autosave():
@@ -83,7 +84,7 @@ def _is_save_allowed(filename: str) -> bool:
 
 
 def _patch_editor_save_file():
-    global _original_save_file
+    global _original_save_file, _original_ask_new_path
     if _original_save_file is not None:
         return
 
@@ -93,24 +94,23 @@ def _patch_editor_save_file():
         return
 
     _original_save_file = Editor.save_file
+    _original_ask_new_path = Editor.ask_new_path
+
+    def wrapped_ask_new_path(self, *args, **kwargs):
+        path = _original_ask_new_path(self, *args, **kwargs)
+        if path and _is_bac_mode_enabled() and _is_forbidden_extension(path):
+            _warn_forbidden_extension()
+            return None
+        return path
 
     def wrapped_save_file(self, *args, **kwargs):
-        target = kwargs.get("ask_filename")
-        if target is None and args:
-            target = args[0]
-
-        if isinstance(target, str) and _is_bac_mode_enabled() and _is_forbidden_extension(target):
+        if _is_bac_mode_enabled() and self._filename and _is_forbidden_extension(self._filename):
             _warn_forbidden_extension()
             return None
 
-        result = _original_save_file(self, *args, **kwargs)
+        return _original_save_file(self, *args, **kwargs)
 
-        if _is_bac_mode_enabled() and result and _is_forbidden_extension(result):
-            _warn_forbidden_extension()
-            return None
-
-        return result
-
+    Editor.ask_new_path = wrapped_ask_new_path
     Editor.save_file = wrapped_save_file
 
 def _on_file_event(event):

--- a/src/thonnycontrib/thonny-autosave/__init__.py
+++ b/src/thonnycontrib/thonny-autosave/__init__.py
@@ -14,6 +14,8 @@ logger.setLevel(51)
 _WARNING_MESSAGE = (
     "Vous devez enregistrer dans C:/Bac{year}/xxxxxx où xxxxxx est votre numéro d'inscription"
 )
+_BLINK_PERIOD_MS = 700
+_should_show_untitled_title = True
 
 
 def toggle_autosave():
@@ -63,17 +65,40 @@ def _on_file_event(event):
         _validate_bac_path(filename)
 
 
-def save_current():
-    logger.info("entering save_current")
-    get_workbench().after(10000, save_current)
-
+def _get_current_editor():
     try:
         editor_notebook = get_workbench().get_editor_notebook()
     except (AssertionError, AttributeError):
+        return None, None
+
+    return editor_notebook, editor_notebook.get_current_editor()
+
+
+def _blink_unsaved_untitled():
+    global _should_show_untitled_title
+    get_workbench().after(_BLINK_PERIOD_MS, _blink_unsaved_untitled)
+
+    editor_notebook, editor = _get_current_editor()
+    if editor is None or editor_notebook is None:
         return
 
-    editor = editor_notebook.get_current_editor()
-    if editor is None:
+    if not _is_bac_mode_enabled() or editor.get_filename(False) is not None:
+        editor_notebook.update_editor_title(editor)
+        return
+
+    if _should_show_untitled_title:
+        editor_notebook.update_editor_title(editor, tr("<untitled>"))
+    else:
+        editor_notebook.update_editor_title(editor, " " * len(tr("<untitled>")))
+
+    _should_show_untitled_title = not _should_show_untitled_title
+
+
+def save_current():
+    get_workbench().after(10000, save_current)
+
+    editor_notebook, editor = _get_current_editor()
+    if editor is None or editor_notebook is None:
         return
 
     filename = editor.get_filename(False)
@@ -83,6 +108,11 @@ def save_current():
     if editor.is_modified() and get_workbench().get_option("general.autosave"):
         if _validate_bac_path(filename):
             editor.save_file()
+
+
+def _on_workbench_ready(event):
+    save_current()
+    _blink_unsaved_untitled()
 
 
 def load_plugin():
@@ -105,4 +135,4 @@ def load_plugin():
     get_workbench().bind("Save", _on_file_event, True)
     get_workbench().bind("SaveAs", _on_file_event, True)
     get_workbench().bind("Open", _on_file_event, True)
-    get_workbench().bind("WorkbenchReady", lambda event: save_current(), True)
+    get_workbench().bind("WorkbenchReady", _on_workbench_ready, True)

--- a/src/thonnycontrib/thonny-autosave/__init__.py
+++ b/src/thonnycontrib/thonny-autosave/__init__.py
@@ -17,6 +17,9 @@ _WARNING_MESSAGE = (
 _BLINK_PERIOD_MS = 700
 _should_show_untitled_title = True
 
+_UI_EXTENSION_WARNING = "En mode Bac, l'enregistrement des fichiers .ui est interdit."
+_original_save_file = None
+
 
 def toggle_autosave():
     get_workbench().set_option("general.autosave", not get_workbench().get_option("general.autosave"))
@@ -59,10 +62,61 @@ def _validate_bac_path(filename: str) -> bool:
     return False
 
 
+
+def _is_forbidden_extension(filename: str) -> bool:
+    return filename.lower().endswith(".ui")
+
+
+def _warn_forbidden_extension():
+    messagebox.showwarning("Mode Bac", _UI_EXTENSION_WARNING, master=get_workbench())
+
+
+def _is_save_allowed(filename: str) -> bool:
+    if not _is_bac_mode_enabled():
+        return True
+
+    if _is_forbidden_extension(filename):
+        _warn_forbidden_extension()
+        return False
+
+    return _validate_bac_path(filename)
+
+
+def _patch_editor_save_file():
+    global _original_save_file
+    if _original_save_file is not None:
+        return
+
+    try:
+        from thonny.editors import Editor
+    except Exception:
+        return
+
+    _original_save_file = Editor.save_file
+
+    def wrapped_save_file(self, *args, **kwargs):
+        target = kwargs.get("ask_filename")
+        if target is None and args:
+            target = args[0]
+
+        if isinstance(target, str) and _is_bac_mode_enabled() and _is_forbidden_extension(target):
+            _warn_forbidden_extension()
+            return None
+
+        result = _original_save_file(self, *args, **kwargs)
+
+        if _is_bac_mode_enabled() and result and _is_forbidden_extension(result):
+            _warn_forbidden_extension()
+            return None
+
+        return result
+
+    Editor.save_file = wrapped_save_file
+
 def _on_file_event(event):
     filename = getattr(event, "filename", "")
     if filename:
-        _validate_bac_path(filename)
+        _is_save_allowed(filename)
 
 
 def _get_current_editor():
@@ -106,11 +160,12 @@ def save_current():
         return
 
     if editor.is_modified() and get_workbench().get_option("general.autosave"):
-        if _validate_bac_path(filename):
+        if _is_save_allowed(filename):
             editor.save_file()
 
 
 def _on_workbench_ready(event):
+    _patch_editor_save_file()
     save_current()
     _blink_unsaved_untitled()
 

--- a/src/thonnycontrib/thonny-autosave/__init__.py
+++ b/src/thonnycontrib/thonny-autosave/__init__.py
@@ -1,49 +1,104 @@
-import sched, time
+import re
+from datetime import datetime
+from logging import getLogger
+from tkinter import messagebox
+
 from thonny import get_workbench
 from thonny.languages import tr
-from logging import getLogger
 
-get_workbench().set_default("general.autosave",True)
+get_workbench().set_default("general.autosave", True)
+get_workbench().set_default("general.bac_mode", False)
 logger = getLogger(__name__)
 logger.setLevel(51)
 
-#logger.exception("dddddd")
+_WARNING_MESSAGE = (
+    "Vous devez enregistrer dans C:/Bac{year}/xxxxxx où xxxxxx est votre numéro d'inscription"
+)
+
 
 def toggle_autosave():
-    if get_workbench().get_option("general.autosave")==False:
-        get_workbench().set_option("general.autosave",True)
-    else:
-        get_workbench().set_option("general.autosave",False)
+    get_workbench().set_option("general.autosave", not get_workbench().get_option("general.autosave"))
 
 
+def toggle_bac_mode():
+    enabled = not get_workbench().get_option("general.bac_mode")
+    get_workbench().set_option("general.bac_mode", enabled)
+    get_workbench().set_option("general.event_logging", enabled)
 
-def save_current(): 
+
+def _is_bac_mode_enabled():
+    return bool(get_workbench().get_option("general.bac_mode"))
+
+
+def _normalize_path(path: str) -> str:
+    return path.replace("\\", "/").strip()
+
+
+def _is_valid_bac_path(filename: str) -> bool:
+    current_year = datetime.now().year
+    normalized = _normalize_path(filename)
+    pattern = rf"^C:/Bac\s*{current_year}/\d{{6}}/"
+    return bool(re.match(pattern, normalized, flags=re.IGNORECASE))
+
+
+def _warn_bac_path():
+    current_year = datetime.now().year
+    messagebox.showwarning("Mode Bac", _WARNING_MESSAGE.format(year=current_year), master=get_workbench())
+
+
+def _validate_bac_path(filename: str) -> bool:
+    if not _is_bac_mode_enabled() or not filename:
+        return True
+
+    if _is_valid_bac_path(filename):
+        return True
+
+    _warn_bac_path()
+    return False
+
+
+def _on_file_event(event):
+    filename = getattr(event, "filename", "")
+    if filename:
+        _validate_bac_path(filename)
+
+
+def save_current():
     logger.info("entering save_current")
-    get_workbench().after(10000 , save_current)
-    # schedule the next call first
-    #scheduler.enter(2, 1, save_current, (scheduler,))
-    try:
-        editor = get_workbench().get_editor_notebook().get_current_editor()
-    except:
+    get_workbench().after(10000, save_current)
+
+    editor = get_workbench().get_editor_notebook().get_current_editor()
+    if editor is None:
         return
-    logger.info("editor exists")
 
     filename = editor.get_filename(False)
     if not filename:
         return
-    logger.info("filename exists")
-    if editor.is_modified() and  get_workbench().get_option("general.autosave"):
-        filename = editor.save_file()
-    
+
+    if editor.is_modified() and get_workbench().get_option("general.autosave"):
+        if _validate_bac_path(filename):
+            editor.save_file()
+
 
 def load_plugin():
-    
     get_workbench().add_command(
         "toggle_autosave",
         "file",
         tr("Autosave"),
         flag_name="general.autosave",
-        handler=toggle_autosave
+        handler=toggle_autosave,
     )
+
+    get_workbench().add_command(
+        "toggle_bac_mode",
+        "file",
+        tr("Mode Bac"),
+        flag_name="general.bac_mode",
+        handler=toggle_bac_mode,
+    )
+
+    get_workbench().bind("Save", _on_file_event, True)
+    get_workbench().bind("SaveAs", _on_file_event, True)
+    get_workbench().bind("Open", _on_file_event, True)
     logger.info("running save_current")
     save_current()


### PR DESCRIPTION
### Motivation
- Provide a school "Bac" mode that enforces students save files into the expected folder structure and enables activity logging while the mode is active.
- Prevent autosave from storing files outside the required `C:/Bac<year>/<6-digits>/` layout and show a clear warning when the path is non-compliant.

### Description
- Add a persistent option `general.bac_mode` and a File menu checkbox command `toggle_bac_mode` to enable/disable Bac mode. (`src/thonnycontrib/thonny-autosave/__init__.py`).
- Wire `general.bac_mode` to Thonny's `general.event_logging` so event logging is turned on when Bac mode is enabled via `toggle_bac_mode`.
- Implement path validation helpers: `_normalize_path`, `_is_valid_bac_path` (uses regex `^C:/Bac\s*{current_year}/\d{6}/`), `_validate_bac_path`, and a French warning shown with `messagebox.showwarning` when the path is invalid.
- Bind to Thonny events `Open`, `Save`, and `SaveAs` (`get_workbench().bind(...)`) to validate file paths on those actions, and protect the periodic autosave (`save_current`) by checking `_validate_bac_path` before saving.

### Testing
- `python -m compileall -q src` was run and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe22b5c2d4832e886115744d6b17ac)